### PR TITLE
move from maxmind.openSync to async maxmind.open

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -6,6 +6,9 @@ env:
 plugins:
   - haraka
 
+parserOptions:
+  ecmaVersion: 2017
+
 extends:
   - eslint:recommended
   - plugin:haraka/recommended

--- a/Changes.md
+++ b/Changes.md
@@ -1,3 +1,6 @@
+## 1.0.10 - 2019-07-16
+
+- move from maxmind.openSync to async maxmind.open, #35
 
 ## 1.0.9 - 2019-07-09
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "haraka-plugin-geoip",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "provide geographic information about mail senders.",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
fix #35 

- used await since we are min node 10 now
- updated eslintrc to work with await

(beware it seems that npm has problems with latest maxmind package releases, pinning to 3.0.5 or lower seems to be necessary to get working installation, see: https://github.com/runk/node-maxmind/issues/197)