### PR TITLE
Fix gi check

### DIFF
--- a/index.js
+++ b/index.js
@@ -401,8 +401,8 @@ exports.received_headers = function (connection) {
 }
 
 function get_country (gi) {
-  if (plugin_name === 'geoip-lite') return get_country_lite(gi)
   if (!gi) return '';
+  if (plugin_name === 'geoip-lite') return get_country_lite(gi)
   if (!gi.country) return ''
   if (!gi.country.iso_code) return '';
   return gi.country.iso_code;


### PR DESCRIPTION
Also in the lite version of the plugin we should check if `gi` is defined.

![image](https://user-images.githubusercontent.com/2115696/131626736-13310f0b-8981-421e-986b-86f3e7f79d9a.png)
